### PR TITLE
Added iota_mam_id binding

### DIFF
--- a/emscripten/src/main.rs
+++ b/emscripten/src/main.rs
@@ -112,6 +112,7 @@ pub use bindings::*;
 '_iota_sign_iss_signature',\
 '_iota_sign_iss_subseed',\
 '_iota_sign_iss_subseed_to_signature',\
+'_iota_mam_id',\
 '_iota_mam_create',\
 '_iota_mam_parse'\
 ]"]


### PR DESCRIPTION
Unfortunately, it was not communicated that `iota_mam_id` is available for creating the correct address for any restricted mode of MAM (including 'private', which is just a null encryption key). This exposes it to emscripten for mam.client.js usage.